### PR TITLE
Quick Snowball fix

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -532,5 +532,6 @@ dofile(path.."/doors.lua")
 dofile(path.."/fire.lua")
 dofile(path.."/chatcommands.lua")
 dofile(path.."/screwdriver.lua")
+dofile(path.."/snow.lua")
 
 end )

--- a/snow.lua
+++ b/snow.lua
@@ -1,0 +1,27 @@
+--[[
+Snow mod rewrite to make it secure for use on landrush
+This is a quick workaround before we can upload
+an working fix which restores original functionality
+]]
+if minetest.get_modpath( 'snow' ) then
+	local entity_prototype = minetest.registered_entities['snow:snowball_entity']
+	if not entity_prototype then
+		print( 'COuld not detect snowball prototype...')
+		return
+	end
+	entity_prototype.on_step = function(self, dtime)
+		self.timer=self.timer+dtime
+		local pos = self.object:getpos()
+		local node = minetest.get_node(pos)
+
+		if self.lastpos.x~=nil then
+			if node.name ~= "air" then
+				if landrush.can_interact( ' ', pos ) then
+					snow.place(pos)
+				end
+				self.object:remove()
+			end
+		end
+		self.lastpos={x=pos.x, y=pos.y, z=pos.z} -- Set lastpos-->Node will be added at last pos outside the node
+	end
+end


### PR DESCRIPTION
This is a quick fix to stop snowballs from punching holes into claimed areas. There might be a better solution available later, but up to now, this was the only way i came up to just prevend it for now. Snow will now not be set on claimed areas ( Even if its the area of the thrower himself )
