### PR TITLE
support for custom chunksizes

### DIFF
--- a/functions.lua
+++ b/functions.lua
@@ -1,5 +1,5 @@
 function landrush.get_chunk(pos)
-	local x = math.floor(pos.x/landrush.config:get("chunkSize"))
+	local x = math.floor((pos.x+.5)/landrush.config:get("chunkSize"))
 	-- 3 levels of vertical protection
 	local y = 0
 
@@ -14,12 +14,12 @@ function landrush.get_chunk(pos)
 	end
 
 
-	local z = math.floor(pos.z/landrush.config:get("chunkSize"))
+	local z = math.floor((pos.x+.5)/landrush.config:get("chunkSize"))
 	return x..","..y..","..z
 end
 
 function landrush.get_chunk_center(pos)
-	local x = math.floor(pos.x/landrush.config:get("chunkSize"))*landrush.config:get("chunkSize")+7.5
+	local x = math.floor(pos.x/landrush.config:get("chunkSize"))*landrush.config:get("chunkSize")+landrush.config:get("chunkSize")/2-.5
 	local y = 0
 
 	if ( pos.y < -200 ) then
@@ -32,7 +32,7 @@ function landrush.get_chunk_center(pos)
 		y = 120
 	end
 
-	local z = math.floor(pos.z/landrush.config:get("chunkSize"))*landrush.config:get("chunkSize")+7.5
+	local z = math.floor(pos.z/landrush.config:get("chunkSize"))*landrush.config:get("chunkSize")+landrush.config:get("chunkSize")/2-.5
 	return {x=x,y=y,z=z}
 end
 


### PR DESCRIPTION
landrush.get_chunk(pos) -> Without this fix claimed areas shown by hud.lua are .5 too big or too small (the border was in the middle of the blocks).

landrush.get_chunk_center(pos) -> Fix for landrush:showarea position when using a custom chunksize.

Existing landclaims with chunksize>16 may move by 1 block with this changes.

Thanks to Ducky!
