### PR TITLE
Have fire check all neighbor node for interact

### DIFF
--- a/fire.lua
+++ b/fire.lua
@@ -1,20 +1,16 @@
-if minetest.get_modpath("fire") and rawget(_G, "fire") then
+if minetest.get_modpath("fire") then
 	landrush.default_flame_should_extinguish = fire.flame_should_extinguish
 
 	function fire.flame_should_extinguish(pos)
-		corner0 = landrush.can_interact({x=pos.x-1,y=pos.y-1,z=pos.z-1},"-!-")
-		corner1 = landrush.can_interact({x=pos.x-1,y=pos.y-1,z=pos.z+1},"-!-")
-		corner2 = landrush.can_interact({x=pos.x-1,y=pos.y+1,z=pos.z-1},"-!-")
-		corner3 = landrush.can_interact({x=pos.x-1,y=pos.y+1,z=pos.z+1},"-!-")
-		corner4 = landrush.can_interact({x=pos.x+1,y=pos.y-1,z=pos.z-1},"-!-")
-		corner5 = landrush.can_interact({x=pos.x+1,y=pos.y-1,z=pos.z+1},"-!-")
-		corner6 = landrush.can_interact({x=pos.x+1,y=pos.y+1,z=pos.z-1},"-!-")
-		corner7 = landrush.can_interact({x=pos.x+1,y=pos.y+1,z=pos.z+1},"-!-")
-		if corner0 and corner1 then
-			return landrush.default_flame_should_extinguish(pos)
-		else
-			return true
+		for x = -1, 1 do
+			for y = -1, 1 do
+				for z = -1, 1 do
+					if not landrush.can_interact({x=pos.x+x,y=pos.y+y,z=pos.z+z},"-!-") then
+						return true
+					end
+				end
+			end
 		end
+		return landrush.default_flame_should_extinguish(pos)
 	end
 end
-


### PR DESCRIPTION
how is checking just corner0 and corner1 enough to pass to the default function?

this look like it was make this way just to kill all the fire but if that is the case, then there is no need to check for all those corners, just return a `true`

otherwise, it should be properly done by checking all 26 (plus 1 which is the fire itself since excluding it is really just micro optimization) next to the fire to see if it is allow to interact with it.